### PR TITLE
chunks util method for batching

### DIFF
--- a/dash/utils/__init__.py
+++ b/dash/utils/__init__.py
@@ -99,3 +99,11 @@ def get_month_range(d=None):
     start = d.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     end = start + relativedelta(months=1)
     return start, end
+
+
+def chunks(data, size):
+    """
+    Yield successive chunks from the given slice-able collection
+    """
+    for i in xrange(0, len(data), size):
+        yield data[i:(i + size)]

--- a/dash/utils/tests.py
+++ b/dash/utils/tests.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 from django.utils import timezone
 from django.test import TestCase
 from temba.types import Contact as TembaContact
-from . import intersection, union, random_string, filter_dict, get_cacheable, get_obj_cacheable, get_month_range
+from . import intersection, union, random_string, filter_dict, get_cacheable, get_obj_cacheable, get_month_range, chunks
 from .sync import temba_compare_contacts, temba_merge_contacts
 
 
@@ -64,6 +64,10 @@ class InitTest(TestCase):
         self.assertEqual(get_month_range(datetime(2014, 2, 10, 12, 30, 0, 0, pytz.timezone("Africa/Kigali"))),
                          (datetime(2014, 2, 1, 0, 0, 0, 0, pytz.timezone("Africa/Kigali")),
                           datetime(2014, 3, 1, 0, 0, 0, 0, pytz.timezone("Africa/Kigali"))))
+
+    def test_chunks(self):
+        self.assertEqual(list(chunks([], 2)), [])
+        self.assertEqual(list(chunks([1, 2, 3, 4, 5], 2)), [[1, 2], [3, 4], [5]])
 
 
 class SyncTest(TestCase):


### PR DESCRIPTION
Gives us a consistent way to do batching of operations on large collections, e.g.

```python
contact_uuids = [...]
contacts = []
for uuid_chunk in chunks(contact_uuids, 25):
  contacts += client.get_contacts(uuids=uuid_chunk)
```
