### PR TITLE
Run tests on Travis

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source = dash
+omit =
+    */migrations/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+sudo: false
+python:
+  - "2.7"
+services:
+  - redis-server
+env:
+  - DJANGO_SETTINGS_MODULE="dash_test_runner.settings_travis"
+install:
+  - pip install -r pip-requires.txt
+before_script:
+  - createdb -E UTF-8 dash -U postgres -O $USER
+  - python manage.py migrate --noinput
+script:
+  - coverage run manage.py test
+  - coverage report --show-missing

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
   - python manage.py migrate --noinput
 script:
   - coverage run manage.py test
-  - coverage report --show-missing
+  - coverage report --show-missing --fail-under 80

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-dash
-====
+# dash
+
+[![Build Status][master-build-image]][travis-ci]
 
 Library utilities for building dashboards against RapidPro
+
+[travis-ci]: https://travis-ci.org/rapidpro/dash/
+[master-build-image]: https://travis-ci.org/rapidpro/dash.svg?branch=master

--- a/dash_test_runner/settings_travis.py
+++ b/dash_test_runner/settings_travis.py
@@ -1,0 +1,10 @@
+from .settings import *  # noqa
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'dash',
+        'USER': 'postgres',
+    }
+}

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -13,6 +13,7 @@ hamlpy
 mock
 Pillow
 phonenumbers
+psycopg2
 python-dateutil
 requests
 sorl-thumbnail==12.1c


### PR DESCRIPTION
Tests are running on Travis for the [Caktus fork](https://travis-ci.org/caktus/dash). 

To get tests running on Travis for `rapidpro/dash`:

1. Turn on Travis testing for rapidpro/dash here: https://travis-ci.org/profile/rapidpro
2. Configure Travis tests to run on pushes and pull requests when a `.travis.yml` file is present: https://travis-ci.org/rapidpro/dash/settings