### PR TITLE
Remove duplicates while maintaining order

### DIFF
--- a/dash/utils/sync.py
+++ b/dash/utils/sync.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from enum import Enum
 from temba.types import Contact as TembaContact
 from . import union, intersection, filter_dict
@@ -154,6 +154,11 @@ def temba_compare_contacts(first, second, fields=None, groups=None):
     return None
 
 
+def remove_duplicates(group):
+    """Remove duplicates from the group while maintaining order."""
+    return OrderedDict.fromkeys(group).keys()
+
+
 def temba_merge_contacts(first, second, mutex_group_sets):
     """
     Merges two Temba contacts, with priority given to the first contact
@@ -172,8 +177,8 @@ def temba_merge_contacts(first, second, mutex_group_sets):
     merged_fields.update(first.fields)
 
     # first merge mutually exclusive group sets
-    first_groups = set(first.groups)
-    second_groups = set(second.groups)
+    first_groups = remove_duplicates(first.groups)
+    second_groups = remove_duplicates(second.groups)
     merged_mutex_groups = []
     for group_set in mutex_group_sets:
         from_first = intersection(first_groups, group_set)


### PR DESCRIPTION
I noticed this test failure in some environments:

```
======================================================================
FAIL: test_temba_merge_contacts (dash.utils.tests.SyncTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/caktus/dash/dash/utils/tests.py", line 133, in test_temba_merge_contacts
    self.assertEqual(sorted(merged.groups), ['000-001', '000-009', '000-010', '000-011'])
AssertionError: Lists differ: [u'000-002', u'000-009', u'000... != [u'000-001', u'000-009', u'000...
First differing element 0:
000-002
000-001
- [u'000-002', u'000-009', u'000-010', u'000-011']
?          ^
+ [u'000-001', u'000-009', u'000-010', u'000-011']
?          ^
```

Turns out that in some Python versions, `set(first.groups)` gives `000-002` before `000-001`, thus causing the unexpected group to be maintained. This pull request ensures that group order is always maintained.