### PR TITLE
Add missing migrations

### DIFF
--- a/dash/orgs/migrations/0012_auto_20150715_1816.py
+++ b/dash/orgs/migrations/0012_auto_20150715_1816.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orgs', '0011_auto_20150710_1612'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='invitation',
+            name='email',
+            field=models.EmailField(help_text='The email to which we send the invitation of the viewer', max_length=254, verbose_name='Email'),
+        ),
+    ]

--- a/dash/orgs/migrations/0013_auto_20150715_1831.py
+++ b/dash/orgs/migrations/0013_auto_20150715_1831.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orgs', '0012_auto_20150715_1816'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='org',
+            name='language',
+            field=models.CharField(help_text='The main language used by this organization', max_length=64, null=True, verbose_name='Language', blank=True),
+        ),
+    ]

--- a/dash/orgs/models.py
+++ b/dash/orgs/models.py
@@ -55,7 +55,7 @@ class Org(SmartModel):
 
     language = models.CharField(
         verbose_name=_("Language"), max_length=64, null=True, blank=True,
-        choices=settings.LANGUAGES, help_text=_("The main language used by this organization"))
+        help_text=_("The main language used by this organization"))
 
     subdomain = models.SlugField(
         verbose_name=_("Subdomain"), null=True, blank=True, max_length=255, unique=True,

--- a/dash/orgs/views.py
+++ b/dash/orgs/views.py
@@ -130,6 +130,10 @@ class OrgForm(forms.ModelForm):
     administrators = forms.ModelMultipleChoiceField(
         queryset=User.objects.exclude(username="root").exclude(username="root2").exclude(pk__lt=0))
 
+    def __init__(self, *args, **kwargs):
+        super(OrgForm, self).__init__(*args, **kwargs)
+        self.fields['language'].choices = settings.LANGUAGES
+
     def clean_email(self):
         email = self.cleaned_data['email']
         if email:


### PR DESCRIPTION
When I ran `python manage.py makemigrations` two new migrations are needed.

1) A missing migration for `Invitation`.
2) Choices for `Org.language` depend on a project setting. When the setting changes, the system detects the need for a migration. To handle this I removed `choices` from the model field definition & added them to the create/edit form instead.