### PR TITLE
Refactor OrgForm + small updates

### DIFF
--- a/dash/dashblocks/templatetags/dashblocks.py
+++ b/dash/dashblocks/templatetags/dashblocks.py
@@ -42,12 +42,11 @@ Example usage::
 """
 from django import template
 from django.conf import settings
-from django.db import models
+
+from dash.dashblocks.models import DashBlockType, DashBlock
+
 
 register = template.Library()
-
-DashBlockType = models.get_model('dashblocks', 'dashblocktype')
-DashBlock = models.get_model('dashblocks', 'dashblock')
 
 
 @register.simple_tag(takes_context=True)

--- a/dash/orgs/forms.py
+++ b/dash/orgs/forms.py
@@ -51,6 +51,6 @@ class OrgForm(forms.ModelForm):
         return domain
 
     class Meta:
-        fields = ('is_active', 'name', 'subdomain', 'domain', 'timezone',
-                  'language', 'api_token', 'logo', 'administrators')
+        fields = ('is_active', 'name', 'language', 'timezone', 'subdomain',
+                  'domain', 'api_token', 'logo', 'administrators')
         model = Org

--- a/dash/orgs/forms.py
+++ b/dash/orgs/forms.py
@@ -51,6 +51,5 @@ class OrgForm(forms.ModelForm):
         return domain
 
     class Meta:
-        fields = ('is_active', 'name', 'language', 'timezone', 'subdomain',
-                  'domain', 'api_token', 'logo', 'administrators')
+        fields = forms.ALL_FIELDS
         model = Org

--- a/dash/orgs/forms.py
+++ b/dash/orgs/forms.py
@@ -1,0 +1,64 @@
+from __future__ import unicode_literals
+
+from timezones.forms import TimeZoneField
+
+from django import forms
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.utils.translation import ugettext_lazy as _
+
+from .models import Org
+
+
+class OrgForm(forms.ModelForm):
+    first_name = forms.CharField(help_text=_("Your first name"))
+    last_name = forms.CharField(help_text=_("Your last name"))
+    email = forms.EmailField(help_text=_("Your email address"))
+    password = forms.CharField(widget=forms.PasswordInput,
+                               help_text=_("Your password, at least eight letters please"))
+    name = forms.CharField(label=_("Organization"),
+                           help_text=_("The name of this organization"))
+
+    subdomain = forms.CharField(help_text=_("The subdomain of this organization"), required=False)
+
+    domain = forms.CharField(help_text=_("The subdomain of this organization"), required=False)
+
+    timezone = TimeZoneField(help_text=_("The timezone your organization is in"))
+
+    administrators = forms.ModelMultipleChoiceField(
+        queryset=User.objects.exclude(username="root").exclude(username="root2").exclude(pk__lt=0))
+
+    def __init__(self, *args, **kwargs):
+        super(OrgForm, self).__init__(*args, **kwargs)
+        self.fields['language'].choices = settings.LANGUAGES
+
+    def clean_email(self):
+        email = self.cleaned_data['email']
+        if email:
+            if User.objects.filter(username__iexact=email):
+                raise forms.ValidationError(_("That email address is already used"))
+
+        return email.lower()
+
+    def clean_password(self):
+        password = self.cleaned_data['password']
+        if password:
+            if not len(password) >= 8:
+                raise forms.ValidationError(_("Passwords must contain at least 8 letters."))
+        return password
+
+    def clean_domain(self):
+        domain = self.cleaned_data['domain']
+        domain = domain.strip().lower()
+        if not domain:
+            return None
+
+        if domain and domain == getattr(settings, 'HOSTNAME', ""):
+            raise forms.ValidationError(_("This domain is used for subdomains"))
+        return domain
+
+    class Meta:
+        fields = ('is_active', 'first_name', 'last_name', 'email', 'password',
+                  'name', 'subdomain', 'domain', 'timezone', 'language',
+                  'api_token', 'logo', 'administrators')
+        model = Org

--- a/dash/orgs/forms.py
+++ b/dash/orgs/forms.py
@@ -16,20 +16,14 @@ class OrgForm(forms.ModelForm):
     email = forms.EmailField(help_text=_("Your email address"))
     password = forms.CharField(widget=forms.PasswordInput,
                                help_text=_("Your password, at least eight letters please"))
-    name = forms.CharField(label=_("Organization"),
-                           help_text=_("The name of this organization"))
 
-    subdomain = forms.CharField(help_text=_("The subdomain of this organization"), required=False)
-
-    domain = forms.CharField(help_text=_("The subdomain of this organization"), required=False)
-
-    timezone = TimeZoneField(help_text=_("The timezone your organization is in"))
-
-    administrators = forms.ModelMultipleChoiceField(
-        queryset=User.objects.exclude(username="root").exclude(username="root2").exclude(pk__lt=0))
+    timezone = TimeZoneField()
 
     def __init__(self, *args, **kwargs):
         super(OrgForm, self).__init__(*args, **kwargs)
+        administrators = User.objects.exclude(username__in=['root', 'root2'])
+        administrators = administrators.exclude(pk__lt=0)
+        self.fields['administrators'].queryset = administrators
         self.fields['language'].choices = settings.LANGUAGES
 
     def clean_email(self):

--- a/dash/orgs/migrations/0014_auto_20150722_1419.py
+++ b/dash/orgs/migrations/0014_auto_20150722_1419.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orgs', '0013_auto_20150715_1831'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='org',
+            name='domain',
+            field=models.CharField(null=True, error_messages={b'unique': 'This domain is not available'}, max_length=255, blank=True, help_text='The custom domain for this organization', unique=True, verbose_name='Domain'),
+        ),
+        migrations.AlterField(
+            model_name='org',
+            name='subdomain',
+            field=models.SlugField(null=True, error_messages={b'unique': 'This subdomain is not available'}, max_length=255, blank=True, help_text='The subdomain for this organization', unique=True, verbose_name='Subdomain'),
+        ),
+        migrations.AlterField(
+            model_name='org',
+            name='timezone',
+            field=models.CharField(default='UTC', help_text='The timezone your organization is in.', max_length=64, verbose_name='Timezone'),
+        ),
+    ]

--- a/dash/orgs/models.py
+++ b/dash/orgs/models.py
@@ -60,15 +60,16 @@ class Org(SmartModel):
     subdomain = models.SlugField(
         verbose_name=_("Subdomain"), null=True, blank=True, max_length=255, unique=True,
         error_messages=dict(unique=_("This subdomain is not available")),
-        help_text=_("The subdomain for this U-Report instance"))
+        help_text=_("The subdomain for this organization"))
 
     domain = models.CharField(
         verbose_name=_("Domain"), null=True, blank=True, max_length=255, unique=True,
         error_messages=dict(unique=_("This domain is not available")),
-        help_text=_("The custom domain for this U-Report instance"))
+        help_text=_("The custom domain for this organization"))
 
     timezone = models.CharField(
-        verbose_name=_("Timezone"), max_length=64, default='UTC')
+        verbose_name=_("Timezone"), max_length=64, default='UTC',
+        help_text=_("The timezone your organization is in."))
 
     api_token = models.CharField(
         max_length=128, null=True, blank=True,

--- a/dash/orgs/templatetags/dashorgs.py
+++ b/dash/orgs/templatetags/dashorgs.py
@@ -4,12 +4,9 @@ import phonenumbers
 import pytz
 
 from django import template
-from django.db import models
 
 
 register = template.Library()
-
-Org = models.get_model('orgs', 'Org')
 
 
 @register.simple_tag()

--- a/dash/orgs/views.py
+++ b/dash/orgs/views.py
@@ -141,10 +141,13 @@ class OrgCRUDL(SmartCRUDL):
 
     class Create(SmartCreateView):
         form_class = OrgForm
-        exclude = ('is_active',)
+        fields = ('name', 'language', 'timezone', 'subdomain',
+                  'domain', 'api_token', 'logo', 'administrators')
 
     class Update(SmartUpdateView):
         form_class = OrgForm
+        fields = ('is_active', 'name', 'language', 'timezone', 'subdomain',
+                  'domain', 'api_token', 'logo', 'administrators')
 
     class List(SmartListView):
         fields = ('name', 'timezone', 'created_on', 'modified_on')

--- a/dash/orgs/views.py
+++ b/dash/orgs/views.py
@@ -489,7 +489,6 @@ class OrgCRUDL(SmartCRUDL):
     class CreateLogin(SmartUpdateView):
         title = ""
         form_class = OrgForm
-        permission = None
         fields = ('first_name', 'last_name', 'email', 'password')
         success_message = ''
         submit_button_name = _("Create")

--- a/dash_test_runner/settings.py
+++ b/dash_test_runner/settings.py
@@ -10,6 +10,8 @@ https://docs.djangoproject.com/en/dev/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+import warnings
+
 from django.utils.translation import ugettext_lazy as _
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -79,7 +81,6 @@ MIDDLEWARE_CLASSES = (
     'dash.orgs.middleware.SetOrgMiddleware',
 )
 
-import warnings
 warnings.filterwarnings('error', r"DateTimeField received a naive datetime",
                         RuntimeWarning, r'django\.db\.models\.fields')
 

--- a/dash_test_runner/settings.py
+++ b/dash_test_runner/settings.py
@@ -8,12 +8,18 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/dev/ref/settings/
 """
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+import logging
 import os
 import warnings
 
 from django.utils.translation import ugettext_lazy as _
 
+
+# Disable logging during test runs.
+logging.disable(logging.CRITICAL)
+
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
@@ -189,29 +195,6 @@ TEMPLATE_DIRS = (
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
 )
-
-# A sample logging configuration. The only tangible logging
-# performed by this configuration is to send an email to
-# the site admins on every HTTP 500 error.
-# See http://docs.djangoproject.com/en/dev/topics/logging for
-# more details on how to customize your logging configuration.
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'mail_admins': {
-            'level': 'ERROR',
-            'class': 'django.utils.log.AdminEmailHandler'
-        }
-    },
-    'loggers': {
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
-            'propagate': True,
-        },
-    }
-}
 
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',  # this is default

--- a/dash_test_runner/tests.py
+++ b/dash_test_runner/tests.py
@@ -496,7 +496,7 @@ class OrgTest(DashTest):
         self.login(self.superuser)
         response = self.client.get(create_url)
         self.assertEquals(200, response.status_code)
-        self.assertEquals(len(response.context['form'].fields), 8)
+        self.assertEquals(len(response.context['form'].fields), 9)
         self.assertFalse(Org.objects.filter(name="kLab"))
         self.assertEquals(User.objects.all().count(), 4)
 

--- a/dash_test_runner/wsgi.py
+++ b/dash_test_runner/wsgi.py
@@ -10,5 +10,5 @@ https://docs.djangoproject.com/en/dev/howto/deployment/wsgi/
 import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dash_test_runner.settings")
 
-from django.core.wsgi import get_wsgi_application
+from django.core.wsgi import get_wsgi_application  # noqa
 application = get_wsgi_application()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/nyaruka/smartmin.git@master#egg=smartmin-1.7.0
+-e git+https://github.com/nyaruka/smartmin.git@master#egg=smartmin-1.8.1
 -e git+https://github.com/rapidpro/rapidpro-python.git@master#egg=rapidpro-python-1.0
 celery-with-redis
 django>=1.7.2


### PR DESCRIPTION
The first 5 commits contain miscellaneous code quality updates that I ran across.

The last 5 commits refactor `OrgForm`:

* Use Django's defaults wherever possible. I kept the "best" `help_text` between model definitions & form definitions so there's a new migration.
* Separate the login creation functionality since it is only relevant in one place & doesn't need to be a `ModelForm`.
* Add the `logo` field to the `OrgCRUDL.Create` view.
* Same order of fields on `OrgCRUDL.Create` and `OrgCRUDL.Update`.