### PR TITLE
OrgForm tweaks

### DIFF
--- a/dash/orgs/forms.py
+++ b/dash/orgs/forms.py
@@ -46,10 +46,9 @@ class OrgForm(forms.ModelForm):
             self.fields['administrators'].queryset = administrators
 
     def clean_domain(self):
-        domain = self.cleaned_data['domain']
-        domain = domain.strip().lower() or None
+        domain = self.cleaned_data['domain'].strip().lower() or None
         if domain and domain == getattr(settings, 'HOSTNAME', ""):
-                raise forms.ValidationError(_("This domain is used for subdomains"))
+            raise forms.ValidationError(_("This domain is used for subdomains"))
         return domain
 
     class Meta:

--- a/dash/orgs/forms.py
+++ b/dash/orgs/forms.py
@@ -34,6 +34,8 @@ class CreateOrgLoginForm(forms.Form):
 
 
 class OrgForm(forms.ModelForm):
+    language = forms.ChoiceField(
+        required=False, choices=[('', '')] + list(settings.LANGUAGES))
     timezone = TimeZoneField()
 
     def __init__(self, *args, **kwargs):
@@ -41,7 +43,6 @@ class OrgForm(forms.ModelForm):
         administrators = User.objects.exclude(username__in=['root', 'root2'])
         administrators = administrators.exclude(pk__lt=0)
         self.fields['administrators'].queryset = administrators
-        self.fields['language'].choices = settings.LANGUAGES
 
     def clean_domain(self):
         domain = self.cleaned_data['domain']

--- a/dash/orgs/forms.py
+++ b/dash/orgs/forms.py
@@ -40,9 +40,10 @@ class OrgForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(OrgForm, self).__init__(*args, **kwargs)
-        administrators = User.objects.exclude(username__in=['root', 'root2'])
-        administrators = administrators.exclude(pk__lt=0)
-        self.fields['administrators'].queryset = administrators
+        if 'administrators' in self.fields:
+            administrators = User.objects.exclude(username__in=['root', 'root2'])
+            administrators = administrators.exclude(pk__lt=0)
+            self.fields['administrators'].queryset = administrators
 
     def clean_domain(self):
         domain = self.cleaned_data['domain']


### PR DESCRIPTION
* Fix indentation
* Change `language` to be a drop-down `ChoiceField`. 
* In the Edutrac project, we extend `OrgForm` and happen to exclude the `administrators` field. Because of this, the `OrgForm.__init__` code failed because the expected field is not in the `fields` dictionary. I've modified the code to make it more tolerant if a field is not present.