### PR TITLE
Contact Sync

### DIFF
--- a/dash/utils/sync.py
+++ b/dash/utils/sync.py
@@ -77,6 +77,8 @@ def sync_pull_contacts(org, contact_class, fields=None, groups=None, last_time=N
     updated_incoming_contacts = []
     if last_time:
         updated_incoming_contacts = client.get_contacts(after=last_time)
+    else:
+        updated_incoming_contacts = client.get_contacts()
 
     # get all existing contacts and organize by their UUID
     existing_contacts = contact_class.objects.filter(org=org)

--- a/dash/utils/sync.py
+++ b/dash/utils/sync.py
@@ -74,6 +74,7 @@ def sync_pull_contacts(org, contact_class, fields=None, groups=None, last_time=N
     """
     # get all remote contacts
     client = org.get_temba_client()
+    updated_incoming_contacts = []
     if last_time:
         updated_incoming_contacts = client.get_contacts(after=last_time)
 

--- a/dash/utils/sync.py
+++ b/dash/utils/sync.py
@@ -93,12 +93,7 @@ def sync_pull_contacts(org, contact_class, fields=None, groups=None,
     failed_uuids = []
 
     for updated_incoming in updated_incoming_contacts:
-        # ignore contacts with no URN
-        if not updated_incoming.urns:
-            logger.warning("Ignoring contact %s with no URN" % updated_incoming.uuid)
-            failed_uuids.append(updated_incoming.uuid)
-            continue
-
+        # delete blocked contacts if deleted_blocked=True
         if updated_incoming.blocked and delete_blocked:
             deleted_uuids.append(updated_incoming.uuid)
 

--- a/dash/utils/sync.py
+++ b/dash/utils/sync.py
@@ -61,7 +61,7 @@ def sync_push_contact(org, contact, change_type, mutex_group_sets):
 
 
 def sync_pull_contacts(org, contact_class, fields=None, groups=None,
-                       last_time=None, delete_blocked=False, ignore_urnless_contacts=False):
+                       last_time=None, delete_blocked=False):
     """
     Pulls updated contacts or all contacts from RapidPro and syncs with local contacts.
     Contact class must define a class method called kwargs_from_temba which generates
@@ -73,7 +73,6 @@ def sync_pull_contacts(org, contact_class, fields=None, groups=None,
     :param groups: the contact group UUIDs used - used to determine if local contact differs
     :param last_time: the last time we pulled contacts, if None, sync all contacts
     :param delete_blocked: if True, delete the blocked contacts
-    :param ignore_urnless_contacts: if True, do not log a warning
     :return: tuple containing list of UUIDs for created, updated, deleted and failed contacts
     """
     # get all remote contacts
@@ -95,7 +94,7 @@ def sync_pull_contacts(org, contact_class, fields=None, groups=None,
 
     for updated_incoming in updated_incoming_contacts:
         # ignore contacts with no URN
-        if not updated_incoming.urns and not ignore_urnless_contacts:
+        if not updated_incoming.urns:
             logger.warning("Ignoring contact %s with no URN" % updated_incoming.uuid)
             failed_uuids.append(updated_incoming.uuid)
             continue

--- a/dash/utils/sync.py
+++ b/dash/utils/sync.py
@@ -85,8 +85,6 @@ def sync_pull_contacts(org, contact_class, fields=None, groups=None, last_time=N
     existing_contacts = contact_class.objects.filter(org=org)
     existing_by_uuid = {contact.uuid: contact for contact in existing_contacts}
 
-    synced_uuids = set()
-
     created_uuids = []
     updated_uuids = []
     deleted_uuids = []
@@ -127,8 +125,6 @@ def sync_pull_contacts(org, contact_class, fields=None, groups=None, last_time=N
 
             contact_class.objects.create(**kwargs)
             created_uuids.append(kwargs['uuid'])
-
-        synced_uuids.add(updated_incoming.uuid)
 
     # any existing contact not in all rapidpro contacts, is now deleted if not
     # already deleted

--- a/dash/utils/sync.py
+++ b/dash/utils/sync.py
@@ -62,14 +62,15 @@ def sync_push_contact(org, contact, change_type, mutex_group_sets):
 
 def sync_pull_contacts(org, contact_class, fields=None, groups=None, last_time=None):
     """
-    Pulls all contacts from RapidPro and syncs with local contacts. Contact
-    class must define a class method called kwargs_from_temba which generates
+    Pulls updated contacts or all contacts from RapidPro and syncs with local contacts.
+    Contact class must define a class method called kwargs_from_temba which generates
     field kwargs from a fetched temba contact.
 
     :param org: the org
     :param contact_class: the contact class type
     :param fields: the contact field keys used - used to determine if local contact differs
     :param groups: the contact group UUIDs used - used to determine if local contact differs
+    :param last_time: the last time we pulled contacts, if None, sync all contacts
     :return: tuple containing list of UUIDs for created, updated, deleted and failed contacts
     """
     # get all remote contacts


### PR DESCRIPTION
This is an update to the sync_pull_contacts() function. There is a new, non-required variable "last_time". 

If last_time is passed in, we only get temba contacts that were updated on or after that time. If last_time is not passed in, we get all contacts.

A separate call is also made to get all temba contacts to compare them against local contacts, if there are any that need to be added to the deleted_uuids list.

This change is part of a tracpro update which we are hoping to push next week. Please let me know if you have any questions. Thanks!