### PR TITLE
Add disabled flag to org task state

### DIFF
--- a/dash/orgs/migrations/0016_taskstate_is_disabled.py
+++ b/dash/orgs/migrations/0016_taskstate_is_disabled.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orgs', '0015_auto_20160209_0926'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='taskstate',
+            name='is_disabled',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/dash/orgs/models.py
+++ b/dash/orgs/models.py
@@ -409,6 +409,8 @@ class TaskState(models.Model):
 
     is_failing = models.BooleanField(default=False)
 
+    is_disabled = models.BooleanField(default=False)
+
     @classmethod
     def get_or_create(cls, org, task_key):
         existing = cls.objects.filter(org=org, task_key=task_key).first()

--- a/dash/orgs/tasks.py
+++ b/dash/orgs/tasks.py
@@ -94,6 +94,9 @@ def maybe_run_for_org(org, task_func, task_key):
     else:
         with r.lock(key):
             state = org.get_task_state(task_key)
+            if state.is_disabled:
+                logger.info("Skipping for org #%d as task is marked disabled" % org.pk)
+                return
 
             logger.info("Started for org #%d..." % org.pk)
 

--- a/dash/orgs/urls.py
+++ b/dash/orgs/urls.py
@@ -5,3 +5,4 @@ from . import views
 
 urlpatterns = views.OrgCRUDL().as_urlpatterns()
 urlpatterns += views.OrgBackgroundCRUDL().as_urlpatterns()
+urlpatterns += views.TaskCRUDL().as_urlpatterns()

--- a/dash/orgs/views.py
+++ b/dash/orgs/views.py
@@ -16,7 +16,7 @@ from smartmin.views import (
     SmartCRUDL, SmartCreateView, SmartReadView, SmartUpdateView,
     SmartListView, SmartFormView, SmartTemplateView)
 from .forms import CreateOrgLoginForm, OrgForm
-from .models import Org, OrgBackground, Invitation
+from .models import Org, OrgBackground, Invitation, TaskState
 
 
 class OrgPermsMixin(object):
@@ -632,3 +632,21 @@ class OrgBackgroundCRUDL(SmartCRUDL):
                     obj.org = org
 
             return obj
+
+
+class TaskCRUDL(SmartCRUDL):
+    actions = ('list',)
+    model = TaskState
+    model_name = _("Task")
+    path = 'task'
+
+    class List(SmartListView):
+        title = _("Tasks")
+        link_fields = ('org',)
+        default_order = ('org__name', 'task_key')
+
+        def lookup_field_link(self, context, field, obj):
+            if field == 'org':
+                return reverse('orgs.org_update', args=[obj.org_id])
+            else:
+                return super(TaskCRUDL.List, self).lookup_field_link(context, field, obj)

--- a/dash_test_runner/settings.py
+++ b/dash_test_runner/settings.py
@@ -269,6 +269,7 @@ SITE_API_HOST = 'http://localhost:8001'
 HOSTNAME = 'ureport.io'
 SITE_CHOOSER_TEMPLATE = 'orgs/org_chooser.html'
 SITE_CHOOSER_URL_NAME = 'orgs.org_chooser'
+SITE_ALLOW_NO_ORG = ('orgs.task_list',)
 
 CACHES = {
     'default': {

--- a/dash_test_runner/tests.py
+++ b/dash_test_runner/tests.py
@@ -1355,6 +1355,25 @@ class OrgTaskTest(DashTest):
         mock_over_time_window.assert_called_once_with(self.org, state2.started_on, state6.started_on)
 
 
+class TaskCRUDLTest(DashTest):
+    def setUp(self):
+        super(TaskCRUDLTest, self).setUp()
+
+        self.org = self.create_org("uganda", self.admin)
+
+    def test_list(self):
+        url = reverse('orgs.task_list', args=[])
+
+        TaskState.get_or_create(self.org, 'test-task-1')
+        TaskState.get_or_create(self.org, 'test-task-2')
+
+        self.login(self.superuser)
+
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(len(response.context['object_list']), 2)
+
+
 class MockResponse(object):
 
     def __init__(self, status_code, content=''):


### PR DESCRIPTION
Also adds very basic list view of org tasks.

In future could be useful to have a management task for disabling/enabling org tasks, e.g.

```./manage.py orgtask enable 1 "contact-pull"```