### PR TITLE
Added recalculate param to get_cacheable and get_obj_cacheable

### DIFF
--- a/dash/utils/__init__.py
+++ b/dash/utils/__init__.py
@@ -60,13 +60,14 @@ def filter_dict(d, keys):
     return {k: v for k, v in six.iteritems(d) if k in keys}
 
 
-def get_cacheable(cache_key, cache_ttl, calculate):
+def get_cacheable(cache_key, cache_ttl, calculate, recalculate=False):
     """
     Gets the result of a method call, using the given key and TTL as a cache
     """
-    cached = cache.get(cache_key)
-    if cached is not None:
-        return json.loads(cached)
+    if not recalculate:
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return json.loads(cached)
 
     calculated = calculate()
     cache.set(cache_key, json.dumps(calculated), cache_ttl)
@@ -74,12 +75,12 @@ def get_cacheable(cache_key, cache_ttl, calculate):
     return calculated
 
 
-def get_obj_cacheable(obj, attr_name, calculate):
+def get_obj_cacheable(obj, attr_name, calculate, recalculate=False):
     """
     Gets the result of a method call, using the given object and attribute name
     as a cache
     """
-    if hasattr(obj, attr_name):
+    if not recalculate and hasattr(obj, attr_name):
         return getattr(obj, attr_name)
 
     calculated = calculate()

--- a/dash/utils/tests.py
+++ b/dash/utils/tests.py
@@ -43,6 +43,7 @@ class InitTest(DashTest):
         self.assertEqual(get_cacheable('test_key:1', 60, calculate1), "CALCULATED")
         cache.set('test_key:1', json.dumps("CACHED"), 60)
         self.assertEqual(get_cacheable('test_key:1', 60, calculate1), "CACHED")
+        self.assertEqual(get_cacheable('test_key:1', 60, calculate1, recalculate=True), "CALCULATED")
 
         # falsey values shouldn't trigger re-calculation
         cache.set('test_key:1', json.dumps(0), 60)
@@ -62,6 +63,7 @@ class InitTest(DashTest):
         self.assertEqual(get_obj_cacheable(self, '_test_value', calculate), "CALCULATED")
         self._test_value = "CACHED"
         self.assertEqual(get_obj_cacheable(self, '_test_value', calculate), "CACHED")
+        self.assertEqual(get_obj_cacheable(self, '_test_value', calculate, recalculate=True), "CALCULATED")
 
     def test_get_month_range(self):
         self.assertEqual(


### PR DESCRIPTION
Useful for testing where you don't want cached values from a method that uses caching.