### PR TITLE
Upgrading pre-Django 1.10-style middleware

### DIFF
--- a/dash/orgs/middleware.py
+++ b/dash/orgs/middleware.py
@@ -8,6 +8,7 @@ from django.core.exceptions import DisallowedHost
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils import translation, timezone
+from django.utils.deprecation import MiddlewareMixin
 from .models import Org
 
 
@@ -39,7 +40,7 @@ ALLOW_NO_ORG = (
 )
 
 
-class SetOrgMiddleware(object):
+class SetOrgMiddleware(MiddlewareMixin):
     """
     Sets the org on the request, based on the subdomain
     """


### PR DESCRIPTION
To be able to support both old and new middleware styles https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-middleware