### PR TITLE
Updates to support Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
 env:
  - DJANGO_VERSION=1.11.15
  - DJANGO_VERSION=2.0.10
+ - DJANGO_VERSION=2.1.5
 services:
  - redis-server
 install:

--- a/dash/users/urls.py
+++ b/dash/users/urls.py
@@ -2,7 +2,7 @@ from smartmin.users.views import Login
 
 from django.conf import settings
 from django.conf.urls import url
-from django.contrib.auth.views import logout
+from django.contrib.auth.views import LogoutView
 
 from . import views
 
@@ -10,7 +10,7 @@ logout_url = getattr(settings, "LOGOUT_REDIRECT_URL", None)
 
 urlpatterns = [
     url(r"^login/$", Login.as_view(), dict(template_name="smartmin/users/login.html"), name="users.user_login"),
-    url(r"^logout/$", logout, dict(redirect_field_name="go", next_page=logout_url), name="users.user_logout"),
+    url(r"^logout/$", LogoutView.as_view(), dict(redirect_field_name="go", next_page=logout_url), name="users.user_logout"),
 ]
 
 urlpatterns += views.UserCRUDL().as_urlpatterns()

--- a/dash_test_runner/settings.py
+++ b/dash_test_runner/settings.py
@@ -36,6 +36,8 @@ INSTALLED_APPS = (
     'sorl.thumbnail',
     'timezone_field',
 
+    'django.contrib.admin',
+
     'smartmin',
     'smartmin.users',
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 celery
-django<2.1
+django
 django-compressor
 django-hamlpy
 django-redis


### PR DESCRIPTION
Addresses https://github.com/rapidpro/dash/issues/112 and requires https://github.com/rapidpro/dash/issues/112