### PR TITLE
Preserve all story images when saving the images form

### DIFF
--- a/dash/stories/views.py
+++ b/dash/stories/views.py
@@ -113,18 +113,22 @@ class StoryCRUDL(SmartCRUDL):
 
             idx = 1
 
+            # the existing image behind each rendered field, so saving can update rows in place
+            self.existing_images = {}
+
             # add existing images
-            for image in self.object.images.all().order_by("pk"):
+            for story_image in self.object.images.filter(is_active=True).order_by("pk"):
                 image_field_name = "image_%d" % idx
                 image_field = forms.ImageField(
                     required=False,
-                    initial=image.image,
+                    initial=story_image.image,
                     label=_("Image %d") % idx,
                     help_text=_("Image to display on story page and in previews. (optional)"),
                     validators=[validate_image_file_extension],
                 )
 
                 self.form.fields[image_field_name] = image_field
+                self.existing_images[image_field_name] = story_image
                 idx += 1
 
             while idx <= 3:
@@ -141,15 +145,20 @@ class StoryCRUDL(SmartCRUDL):
         def post_save(self, obj):
             obj = super(StoryCRUDL.Images, self).post_save(obj)
 
-            # remove our existing images
-            self.object.images.all().delete()
-
-            # overwrite our new ones, iterating over all rendered image fields
+            # for each rendered image field, keep the existing image if it is unchanged, remove it if it was
+            # cleared or replaced, and create a new image for each new upload
             for field_name in self.form.fields:
                 if not field_name.startswith("image_"):
                     continue
 
                 image = self.form.cleaned_data.get(field_name, None)
+                existing = self.existing_images.get(field_name)
+
+                if existing:
+                    if image == existing.image:  # unchanged, keep as is
+                        continue
+
+                    existing.delete()
 
                 if image:
                     StoryImage.objects.create(

--- a/dash/stories/views.py
+++ b/dash/stories/views.py
@@ -144,10 +144,12 @@ class StoryCRUDL(SmartCRUDL):
             # remove our existing images
             self.object.images.all().delete()
 
-            # overwrite our new ones
-            # TODO: this could probably be done more elegantly
-            for idx in range(1, 4):
-                image = self.form.cleaned_data.get("image_%d" % idx, None)
+            # overwrite our new ones, iterating over all rendered image fields
+            for field_name in self.form.fields:
+                if not field_name.startswith("image_"):
+                    continue
+
+                image = self.form.cleaned_data.get(field_name, None)
 
                 if image:
                     StoryImage.objects.create(

--- a/test_runner/tests.py
+++ b/test_runner/tests.py
@@ -1,6 +1,5 @@
 import zoneinfo
-from dash.tags.models import Tag
-from unittest.mock import Mock, patch, call
+from unittest.mock import Mock, call, patch
 
 import valkey
 from smartmin.tests import SmartminTest
@@ -25,8 +24,9 @@ from dash.orgs.models import Invitation, Org, OrgBackend, OrgBackground, TaskSta
 from dash.orgs.tasks import org_task
 from dash.orgs.templatetags.dashorgs import display_time, national_phone
 from dash.stories.models import Story, StoryImage
-from dash.utils import random_string
+from dash.tags.models import Tag
 from dash.test import MockResponse
+from dash.utils import random_string
 
 
 class UserTest(SmartminTest):
@@ -2169,6 +2169,54 @@ class StoryTest(DashTest):
         self.assertEqual(response.request["PATH_INFO"], reverse("stories.story_list"))
 
         self.clear_uploads()
+
+    def test_images_story_preserves_extra_images(self):
+        import os
+
+        story1 = Story.objects.create(
+            title="foo",
+            content="bar",
+            category=self.health_uganda,
+            org=self.uganda,
+            created_by=self.admin,
+            modified_by=self.admin,
+        )
+
+        # a story can have more than 3 images when they are created outside the images form
+        for i in range(1, 5):
+            StoryImage.objects.create(
+                name="image %d" % i,
+                story=story1,
+                image="stories/someimage%d.jpg" % i,
+                created_by=self.admin,
+                modified_by=self.admin,
+            )
+
+        images_url = reverse("stories.story_images", args=[story1.pk])
+
+        self.login(self.admin)
+        response = self.client.get(images_url, SERVER_NAME="uganda.ureport.io")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["form"].fields), 4)
+        for field in response.context["form"].fields:
+            self.assertTrue(response.context["form"].fields[field].initial)
+
+        # posting without changes should preserve all 4 images
+        response = self.client.post(images_url, dict(), follow=True, SERVER_NAME="uganda.ureport.io")
+        self.assertEqual(response.request["PATH_INFO"], reverse("stories.story_list"))
+        self.assertEqual(StoryImage.objects.filter(story=story1).count(), 4)
+
+        # submitting a new image for one of the fields should still preserve all 4 images
+        upload = open("%s/image.jpg" % settings.TESTFILES_DIR, "rb")
+        post_data = dict(image_2=upload)
+        response = self.client.post(images_url, post_data, follow=True, SERVER_NAME="uganda.ureport.io")
+        self.assertEqual(response.request["PATH_INFO"], reverse("stories.story_list"))
+        self.assertEqual(StoryImage.objects.filter(story=story1).count(), 4)
+
+        # remove the file we uploaded, other images do not have files on disk
+        for story_image in StoryImage.objects.filter(story=story1):
+            if os.path.exists(story_image.image.path):
+                os.remove(story_image.image.path)
 
 
 class DashBlockTypeTest(DashTest):

--- a/test_runner/tests.py
+++ b/test_runner/tests.py
@@ -2192,6 +2192,25 @@ class StoryTest(DashTest):
                 modified_by=self.admin,
             )
 
+        # a soft deleted image should not appear on the form nor be resurrected by saving it
+        inactive_image = StoryImage.objects.create(
+            name="inactive image",
+            story=story1,
+            image="stories/inactiveimage.jpg",
+            created_by=self.admin,
+            modified_by=self.admin,
+            is_active=False,
+        )
+
+        def active_images():
+            return list(
+                StoryImage.objects.filter(story=story1, is_active=True)
+                .order_by("pk")
+                .values_list("pk", "name", "image")
+            )
+
+        original_images = active_images()
+
         images_url = reverse("stories.story_images", args=[story1.pk])
 
         self.login(self.admin)
@@ -2201,17 +2220,32 @@ class StoryTest(DashTest):
         for field in response.context["form"].fields:
             self.assertTrue(response.context["form"].fields[field].initial)
 
-        # posting without changes should preserve all 4 images
+        # posting without changes should preserve all 4 images with their names and metadata intact
         response = self.client.post(images_url, dict(), follow=True, SERVER_NAME="uganda.ureport.io")
         self.assertEqual(response.request["PATH_INFO"], reverse("stories.story_list"))
-        self.assertEqual(StoryImage.objects.filter(story=story1).count(), 4)
+        self.assertEqual(active_images(), original_images)
 
-        # submitting a new image for one of the fields should still preserve all 4 images
+        # submitting a new image for one of the fields should only replace that image
         upload = open("%s/image.jpg" % settings.TESTFILES_DIR, "rb")
         post_data = dict(image_2=upload)
         response = self.client.post(images_url, post_data, follow=True, SERVER_NAME="uganda.ureport.io")
         self.assertEqual(response.request["PATH_INFO"], reverse("stories.story_list"))
-        self.assertEqual(StoryImage.objects.filter(story=story1).count(), 4)
+
+        images = active_images()
+        self.assertEqual(len(images), 4)
+        self.assertEqual(images[:3], [original_images[0], original_images[2], original_images[3]])
+        self.assertNotIn(images[3], original_images)
+
+        # checking the clear checkbox for a field should remove exactly that image
+        post_data = {"image_2-clear": "on"}
+        response = self.client.post(images_url, post_data, follow=True, SERVER_NAME="uganda.ureport.io")
+        self.assertEqual(response.request["PATH_INFO"], reverse("stories.story_list"))
+        self.assertEqual(active_images(), [original_images[0], original_images[3], images[3]])
+
+        # the soft deleted image was never resurrected
+        inactive_image.refresh_from_db()
+        self.assertFalse(inactive_image.is_active)
+        self.assertEqual(StoryImage.objects.filter(story=story1, is_active=False).count(), 1)
 
         # remove the file we uploaded, other images do not have files on disk
         for story_image in StoryImage.objects.filter(story=story1):


### PR DESCRIPTION
The story images form renders a field for every existing image, but on save it deleted all of the story's images and recreated only the first three — a story with four or more images (e.g. created via the API or shell) silently lost the rest when an editor saved the page.

The save handler now iterates over every rendered image field, so nothing that was displayed is dropped; clearing a field still removes that image. Includes a regression test with a 4-image story.