### PR TITLE
Send invitation emails via async task and use crypto-safe secrets

### DIFF
--- a/dash/orgs/models.py
+++ b/dash/orgs/models.py
@@ -1,5 +1,4 @@
 import json
-import secrets
 from functools import partial
 from pydoc import locate
 
@@ -14,7 +13,7 @@ from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
-from dash.utils import generate_file_path
+from dash.utils import generate_file_path, random_string
 from dash.utils.email import send_dash_email
 
 STATE = 1
@@ -284,7 +283,7 @@ class Invitation(SmartModel):
         if not self.secret:
             secret = Invitation.generate_random_string(64)
 
-            while Invitation.objects.filter(secret=secret):
+            while Invitation.objects.filter(secret=secret).exists():
                 secret = Invitation.generate_random_string(64)
 
             self.secret = secret
@@ -294,11 +293,9 @@ class Invitation(SmartModel):
     @classmethod
     def generate_random_string(cls, length):
         """
-        Generatesa a [length] characters alpha numeric secret
+        Generates a [length] characters alpha numeric secret
         """
-        # avoid things that could be mistaken ex: 'I' and '1'
-        letters = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
-        return "".join([secrets.choice(letters) for _ in range(length)])
+        return random_string(length)
 
     def send_invitation(self):
         from .tasks import send_invitation_email_task

--- a/dash/orgs/models.py
+++ b/dash/orgs/models.py
@@ -1,5 +1,5 @@
 import json
-import random
+import secrets
 from functools import partial
 from pydoc import locate
 
@@ -9,7 +9,7 @@ from timezone_field import TimeZoneField
 
 from django.conf import settings
 from django.contrib.auth.models import Group, User
-from django.db import models
+from django.db import models, transaction
 from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
@@ -298,12 +298,12 @@ class Invitation(SmartModel):
         """
         # avoid things that could be mistaken ex: 'I' and '1'
         letters = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
-        return "".join([random.choice(letters) for _ in range(length)])
+        return "".join([secrets.choice(letters) for _ in range(length)])
 
     def send_invitation(self):
         from .tasks import send_invitation_email_task
 
-        send_invitation_email_task(self.id)
+        transaction.on_commit(partial(send_invitation_email_task.delay, self.id))
 
     def send_email(self):
         # no=op if we do not know the email

--- a/dash/orgs/tasks.py
+++ b/dash/orgs/tasks.py
@@ -21,6 +21,8 @@ def send_invitation_email_task(invitation_id):
     invitation = Invitation.objects.filter(pk=invitation_id).first()
     if invitation:
         invitation.send_email()
+    else:
+        logger.warning("invitation %s no longer exists", invitation_id)
 
 
 @shared_task

--- a/dash/orgs/tasks.py
+++ b/dash/orgs/tasks.py
@@ -18,8 +18,9 @@ logger = logging.getLogger(__name__)
 
 @shared_task(track_started=True, name="send_invitation_email_task")
 def send_invitation_email_task(invitation_id):
-    invitation = Invitation.objects.get(pk=invitation_id)
-    invitation.send_email()
+    invitation = Invitation.objects.filter(pk=invitation_id).first()
+    if invitation:
+        invitation.send_email()
 
 
 @shared_task

--- a/dash/utils/__init__.py
+++ b/dash/utils/__init__.py
@@ -1,7 +1,7 @@
 import calendar
 import json
 import os
-import random
+import secrets
 from collections import OrderedDict
 from datetime import datetime, timezone as tzone
 from itertools import islice
@@ -50,7 +50,7 @@ def random_string(length):
     """
     # avoid things that could be mistaken ex: 'I' and '1'
     letters = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
-    return "".join([random.choice(letters) for _ in range(length)])
+    return "".join([secrets.choice(letters) for _ in range(length)])
 
 
 def filter_dict(d, keys):

--- a/test_runner/settings.py
+++ b/test_runner/settings.py
@@ -180,6 +180,8 @@ LOGOUT_REDIRECT_URL = "/"
 # ----------------------------------------------------------------------------
 CELERY_RESULT_BACKEND = None
 CELERY_BROKER_URL = "redis://localhost:6379/4"
+CELERY_TASK_ALWAYS_EAGER = True
+CELERY_TASK_EAGER_PROPAGATES = True
 
 # RapidPRO
 SITE_API_HOST = "http://localhost:8001"

--- a/test_runner/tests.py
+++ b/test_runner/tests.py
@@ -1,6 +1,5 @@
 import zoneinfo
-from dash.tags.models import Tag
-from unittest.mock import Mock, patch, call
+from unittest.mock import Mock, call, patch
 
 import valkey
 from smartmin.tests import SmartminTest
@@ -25,8 +24,9 @@ from dash.orgs.models import Invitation, Org, OrgBackend, OrgBackground, TaskSta
 from dash.orgs.tasks import org_task
 from dash.orgs.templatetags.dashorgs import display_time, national_phone
 from dash.stories.models import Story, StoryImage
-from dash.utils import random_string
+from dash.tags.models import Tag
 from dash.test import MockResponse
+from dash.utils import random_string
 
 
 class UserTest(SmartminTest):
@@ -975,7 +975,8 @@ class OrgTest(DashTest):
         # now post with right email
         post_data["emails"] = "norkans7@gmail.com"
         post_data["user_group"] = "A"
-        response = self.client.post(manage_accounts_url, post_data, SERVER_NAME="uganda.ureport.io")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(manage_accounts_url, post_data, SERVER_NAME="uganda.ureport.io")
 
         # an invitation is created and sent by email
         self.assertEqual(1, Invitation.objects.all().count())
@@ -993,7 +994,8 @@ class OrgTest(DashTest):
         # send another invitation, different group
         post_data["emails"] = "norkans7@gmail.com"
         post_data["user_group"] = "E"
-        self.client.post(manage_accounts_url, post_data, SERVER_NAME="uganda.ureport.io")
+        with self.captureOnCommitCallbacks(execute=True):
+            self.client.post(manage_accounts_url, post_data, SERVER_NAME="uganda.ureport.io")
 
         # old invite should be updated
         new_invite = Invitation.objects.all().first()
@@ -1006,7 +1008,8 @@ class OrgTest(DashTest):
         # post many emails to the form
         post_data["emails"] = "norbert@nyaruka.com,code@nyaruka.com"
         post_data["user_group"] = "A"
-        self.client.post(manage_accounts_url, post_data, SERVER_NAME="uganda.ureport.io")
+        with self.captureOnCommitCallbacks(execute=True):
+            self.client.post(manage_accounts_url, post_data, SERVER_NAME="uganda.ureport.io")
 
         # now 2 new invitations are created and sent
         self.assertEqual(3, Invitation.objects.all().count())


### PR DESCRIPTION
`Invitation.send_invitation()` invoked the celery task function directly, running the email send synchronously inside the web request — an SMTP outage could 500 the accounts management view partway through updating org membership. Invitation secrets were also generated with the non-cryptographic `random` module despite gating account creation.

The email task is now dispatched with `.delay()` inside `transaction.on_commit` (so a worker can't race the uncommitted row), the task no-ops gracefully if the invitation has been deleted, and secrets use `secrets.choice`. Test settings enable celery eager mode so the email assertions exercise the async path.