### PR TITLE
Guard org join and create login views against already-used invitations

### DIFF
--- a/dash/orgs/views.py
+++ b/dash/orgs/views.py
@@ -16,6 +16,7 @@ from django.contrib import messages
 from django.contrib.auth import authenticate, get_user_model, login
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
+from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -506,36 +507,36 @@ class OrgCRUDL(SmartCRUDL):
             return None
 
         def form_valid(self, form):
-            # make sure the invitation is still valid before creating anything, e.g. it may have
-            # been used already by a duplicate submission
-            invitation = self.get_invitation()
-            if not invitation:
-                messages.info(
-                    self.request,
-                    _("Your invitation link is invalid. Please contact your organization administrator."),
+            with transaction.atomic():
+                # claim the invitation atomically so that a concurrent duplicate submission can't also use it
+                claimed = Invitation.objects.filter(secret=self.kwargs["secret"], is_active=True).update(
+                    is_active=False
                 )
-                return HttpResponseRedirect("/")
+                if not claimed:
+                    messages.info(
+                        self.request,
+                        _("Your invitation link is invalid. Please contact your organization administrator."),
+                    )
+                    return HttpResponseRedirect("/")
 
-            user = Org.create_user(self.form.cleaned_data["email"], self.form.cleaned_data["password"])
-            user.first_name = self.form.cleaned_data["first_name"]
-            user.last_name = self.form.cleaned_data["last_name"]
-            user.save()
+                invitation = Invitation.objects.filter(secret=self.kwargs["secret"]).first()
 
-            # log the user in
-            user = authenticate(username=user.username, password=self.form.cleaned_data["password"])
-            login(self.request, user)
+                user = Org.create_user(self.form.cleaned_data["email"], self.form.cleaned_data["password"])
+                user.first_name = self.form.cleaned_data["first_name"]
+                user.last_name = self.form.cleaned_data["last_name"]
+                user.save()
 
-            obj = invitation.org
-            if invitation.user_group == "A":
-                obj.administrators.add(user)
-            elif invitation.user_group == "E":
-                obj.editors.add(user)
+                # log the user in
+                user = authenticate(username=user.username, password=self.form.cleaned_data["password"])
+                login(self.request, user)
 
-            # make the invitation inactive
-            invitation.is_active = False
-            invitation.save()
+                obj = invitation.org
+                if invitation.user_group == "A":
+                    obj.administrators.add(user)
+                elif invitation.user_group == "E":
+                    obj.editors.add(user)
 
-            return super(OrgCRUDL.CreateLogin, self).form_valid(form)
+                return super(OrgCRUDL.CreateLogin, self).form_valid(form)
 
         @classmethod
         def derive_url_pattern(cls, path, action):
@@ -556,7 +557,7 @@ class OrgCRUDL(SmartCRUDL):
 
         def derive_title(self):
             org = self.get_object()
-            return _("Join %(name)s") % {"name": org.name}
+            return _("Join %(name)s") % {"name": org.name} if org else _("Join")
 
         def get_context_data(self, **kwargs):
             context = super(OrgCRUDL.CreateLogin, self).get_context_data(**kwargs)
@@ -599,36 +600,36 @@ class OrgCRUDL(SmartCRUDL):
 
         def derive_title(self):
             org = self.get_object()
-            return _("Join %(name)s") % {"name": org.name}
+            return _("Join %(name)s") % {"name": org.name} if org else _("Join")
 
         def form_valid(self, form):
-            # make sure the invitation is still valid before updating anything, e.g. it may have
-            # been used already by a duplicate submission
-            if not self.get_invitation():
-                messages.info(
-                    self.request,
-                    _("Your invitation link has expired. Please contact your organization administrator."),
+            with transaction.atomic():
+                # claim the invitation atomically so that a concurrent duplicate submission can't also use it
+                claimed = Invitation.objects.filter(secret=self.kwargs["secret"], is_active=True).update(
+                    is_active=False
                 )
-                return HttpResponseRedirect("/")
+                if not claimed:
+                    messages.info(
+                        self.request,
+                        _("Your invitation link has expired. Please contact your organization administrator."),
+                    )
+                    return HttpResponseRedirect("/")
 
-            return super(OrgCRUDL.Join, self).form_valid(form)
+                self.invitation = Invitation.objects.filter(secret=self.kwargs["secret"]).first()
+
+                return super(OrgCRUDL.Join, self).form_valid(form)
 
         def save(self, org):
-            invitation = self.get_invitation()
-            if invitation:
-                org = invitation.org
-                if invitation.user_group == "A":
-                    org.administrators.add(self.request.user)
-                elif invitation.user_group == "E":
-                    org.editors.add(self.request.user)
+            invitation = self.invitation
+            org = invitation.org
+            if invitation.user_group == "A":
+                org.administrators.add(self.request.user)
+            elif invitation.user_group == "E":
+                org.editors.add(self.request.user)
 
-                # make the invitation inactive
-                invitation.is_active = False
-                invitation.save()
-
-                # set the active org on this user
-                self.request.user.set_org(org)
-                self.request.session["org_id"] = org.pk
+            # set the active org on this user
+            self.request.user.set_org(org)
+            self.request.session["org_id"] = org.pk
 
         @classmethod
         def derive_url_pattern(cls, path, action):

--- a/dash/orgs/views.py
+++ b/dash/orgs/views.py
@@ -506,18 +506,26 @@ class OrgCRUDL(SmartCRUDL):
             return None
 
         def form_valid(self, form):
+            # make sure the invitation is still valid before creating anything, e.g. it may have
+            # been used already by a duplicate submission
+            invitation = self.get_invitation()
+            if not invitation:
+                messages.info(
+                    self.request,
+                    _("Your invitation link is invalid. Please contact your organization administrator."),
+                )
+                return HttpResponseRedirect("/")
+
             user = Org.create_user(self.form.cleaned_data["email"], self.form.cleaned_data["password"])
             user.first_name = self.form.cleaned_data["first_name"]
             user.last_name = self.form.cleaned_data["last_name"]
             user.save()
 
-            invitation = self.get_invitation()
-
             # log the user in
             user = authenticate(username=user.username, password=self.form.cleaned_data["password"])
             login(self.request, user)
 
-            obj = self.get_object()
+            obj = invitation.org
             if invitation.user_group == "A":
                 obj.administrators.add(user)
             elif invitation.user_group == "E":
@@ -593,10 +601,22 @@ class OrgCRUDL(SmartCRUDL):
             org = self.get_object()
             return _("Join %(name)s") % {"name": org.name}
 
+        def form_valid(self, form):
+            # make sure the invitation is still valid before updating anything, e.g. it may have
+            # been used already by a duplicate submission
+            if not self.get_invitation():
+                messages.info(
+                    self.request,
+                    _("Your invitation link has expired. Please contact your organization administrator."),
+                )
+                return HttpResponseRedirect("/")
+
+            return super(OrgCRUDL.Join, self).form_valid(form)
+
         def save(self, org):
-            org = self.get_object()
             invitation = self.get_invitation()
-            if org:
+            if invitation:
+                org = invitation.org
                 if invitation.user_group == "A":
                     org.administrators.add(self.request.user)
                 elif invitation.user_group == "E":

--- a/test_runner/tests.py
+++ b/test_runner/tests.py
@@ -1,6 +1,5 @@
 import zoneinfo
-from dash.tags.models import Tag
-from unittest.mock import Mock, patch, call
+from unittest.mock import Mock, call, patch
 
 import valkey
 from smartmin.tests import SmartminTest
@@ -25,8 +24,9 @@ from dash.orgs.models import Invitation, Org, OrgBackend, OrgBackground, TaskSta
 from dash.orgs.tasks import org_task
 from dash.orgs.templatetags.dashorgs import display_time, national_phone
 from dash.stories.models import Story, StoryImage
-from dash.utils import random_string
+from dash.tags.models import Tag
 from dash.test import MockResponse
+from dash.utils import random_string
 
 
 class UserTest(SmartminTest):
@@ -1071,6 +1071,21 @@ class OrgTest(DashTest):
             response = self.client.post(join_url, post_data, follow=True, SERVER_NAME="uganda.ureport.io")
             self.assertEqual(response.request["PATH_INFO"], "/example/home")
 
+        # posting again with an invitation that has already been used should not error, just redirect away
+        self.org.editors.remove(self.invited_editor)
+
+        response = self.client.post(editor_join_url, dict(), follow=True, SERVER_NAME="uganda.ureport.io")
+        self.assertEqual(response.request["PATH_INFO"], "/")
+        self.assertFalse(self.invited_editor in self.org.editors.all())
+
+        # even if the invitation is consumed after the request passes pre_process
+        with patch("dash.orgs.views.OrgCRUDL.Join.pre_process") as mock_pre_process:
+            mock_pre_process.return_value = None
+
+            response = self.client.post(editor_join_url, dict(), follow=True, SERVER_NAME="uganda.ureport.io")
+            self.assertEqual(response.request["PATH_INFO"], "/")
+            self.assertFalse(self.invited_editor in self.org.editors.all())
+
     def test_create_login(self):
         admin_invitation = Invitation.objects.create(
             org=self.org, user_group="A", email="norkans7@gmail.com", created_by=self.admin, modified_by=self.admin
@@ -1151,6 +1166,27 @@ class OrgTest(DashTest):
         self.assertTrue(User.objects.filter(email="norkans7@gmail.com"))
         self.assertFalse(Invitation.objects.get(pk=admin_invitation.pk).is_active)
         self.assertTrue(Invitation.objects.get(pk=viewer_invitation.pk).is_active)
+
+        # posting again with an invitation that has already been used should not create a user, just redirect away
+        self.client.logout()
+
+        post_data = dict()
+        post_data["first_name"] = "Bob"
+        post_data["last_name"] = "User"
+        post_data["email"] = "bob@nyaruka.com"
+        post_data["password"] = "bobuserpassword"
+
+        response = self.client.post(admin_create_login_url, post_data, follow=True, SERVER_NAME="uganda.ureport.io")
+        self.assertEqual(response.request["PATH_INFO"], "/")
+        self.assertFalse(User.objects.filter(email="bob@nyaruka.com"))
+
+        # even if the invitation is consumed after the request passes pre_process
+        with patch("dash.orgs.views.OrgCRUDL.CreateLogin.pre_process") as mock_pre_process:
+            mock_pre_process.return_value = None
+
+            response = self.client.post(admin_create_login_url, post_data, follow=True, SERVER_NAME="uganda.ureport.io")
+            self.assertEqual(response.request["PATH_INFO"], "/")
+            self.assertFalse(User.objects.filter(email="bob@nyaruka.com"))
 
     def test_dashorgs_templatetags(self):
         self.assertEqual(display_time("2014-11-04T15:11:34Z", self.org), "Nov 04, 2014 15:11")

--- a/test_runner/tests.py
+++ b/test_runner/tests.py
@@ -1074,16 +1074,19 @@ class OrgTest(DashTest):
         # posting again with an invitation that has already been used should not error, just redirect away
         self.org.editors.remove(self.invited_editor)
 
-        response = self.client.post(editor_join_url, dict(), follow=True, SERVER_NAME="uganda.ureport.io")
-        self.assertEqual(response.request["PATH_INFO"], "/")
+        response = self.client.post(editor_join_url, dict(), SERVER_NAME="uganda.ureport.io")
+        self.assertEqual(302, response.status_code)
+        self.assertEqual("/", response.url)
         self.assertFalse(self.invited_editor in self.org.editors.all())
 
-        # even if the invitation is consumed after the request passes pre_process
-        with patch("dash.orgs.views.OrgCRUDL.Join.pre_process") as mock_pre_process:
-            mock_pre_process.return_value = None
+        # simulate a concurrent second submission: the invitation still looks active when the request
+        # is checked but has been consumed by the time it is claimed
+        with patch("dash.orgs.views.OrgCRUDL.Join.get_invitation") as mock_get_invitation:
+            mock_get_invitation.return_value = editor_invitation
 
-            response = self.client.post(editor_join_url, dict(), follow=True, SERVER_NAME="uganda.ureport.io")
-            self.assertEqual(response.request["PATH_INFO"], "/")
+            response = self.client.post(editor_join_url, dict(), SERVER_NAME="uganda.ureport.io")
+            self.assertEqual(302, response.status_code)
+            self.assertEqual("/", response.url)
             self.assertFalse(self.invited_editor in self.org.editors.all())
 
     def test_create_login(self):
@@ -1176,17 +1179,21 @@ class OrgTest(DashTest):
         post_data["email"] = "bob@nyaruka.com"
         post_data["password"] = "bobuserpassword"
 
-        response = self.client.post(admin_create_login_url, post_data, follow=True, SERVER_NAME="uganda.ureport.io")
-        self.assertEqual(response.request["PATH_INFO"], "/")
+        response = self.client.post(admin_create_login_url, post_data, SERVER_NAME="uganda.ureport.io")
+        self.assertEqual(302, response.status_code)
+        self.assertEqual("/", response.url)
         self.assertFalse(User.objects.filter(email="bob@nyaruka.com"))
 
-        # even if the invitation is consumed after the request passes pre_process
-        with patch("dash.orgs.views.OrgCRUDL.CreateLogin.pre_process") as mock_pre_process:
-            mock_pre_process.return_value = None
+        # simulate a concurrent second submission: the invitation still looks active when the request
+        # is checked but has been consumed by the time it is claimed
+        with patch("dash.orgs.views.OrgCRUDL.CreateLogin.get_invitation") as mock_get_invitation:
+            mock_get_invitation.return_value = admin_invitation
 
-            response = self.client.post(admin_create_login_url, post_data, follow=True, SERVER_NAME="uganda.ureport.io")
-            self.assertEqual(response.request["PATH_INFO"], "/")
+            response = self.client.post(admin_create_login_url, post_data, SERVER_NAME="uganda.ureport.io")
+            self.assertEqual(302, response.status_code)
+            self.assertEqual("/", response.url)
             self.assertFalse(User.objects.filter(email="bob@nyaruka.com"))
+            self.assertEqual(1, self.org.administrators.filter(email="norkans7@gmail.com").count())
 
     def test_dashorgs_templatetags(self):
         self.assertEqual(display_time("2014-11-04T15:11:34Z", self.org), "Nov 04, 2014 15:11")


### PR DESCRIPTION
On a double submit, the create-login view created and logged in the new user before re-fetching the invitation; with the invitation already consumed this raised an AttributeError → 500, leaving an orphaned logged-in user belonging to no org. The join view had the same None dereference.

Both views now validate the invitation first and redirect with the existing invalid/expired-invitation message before any user is created or membership mutated. Tests cover the double-submit race directly.