### PR TITLE
Fix crash and lost-update window when sync deletion candidates change concurrently

### DIFF
--- a/dash/utils/sync.py
+++ b/dash/utils/sync.py
@@ -200,13 +200,15 @@ def sync_local_to_set(org, syncer, remote_set) -> dict:
         identity = syncer.identify_local(local)
 
         with syncer.lock(org, identity):
-            # re-fetch inside the lock and re-check that this object still qualifies for deletion, as a concurrent
-            # sync may have changed it since the queryset was evaluated
-            local = syncer.fetch_local(org, identity)
-
-            if local and local.is_active and identity not in remote_identities:
+            # re-check inside the lock that this object still exists and is active, as a concurrent sync may have
+            # deactivated or hard-deleted it since the queryset was evaluated. Note this only sees committed state
+            # under READ COMMITTED/autocommit - callers must not wrap syncs in an outer transaction that outlives
+            # the lock.
+            if syncer.fetch_all(org).filter(pk=local.pk, is_active=True).exists():
                 syncer.delete_local(local)
                 outcome_counts[SyncOutcome.deleted] += 1
+            else:
+                outcome_counts[SyncOutcome.ignored] += 1
 
     return outcome_counts
 

--- a/dash/utils/sync.py
+++ b/dash/utils/sync.py
@@ -197,9 +197,16 @@ def sync_local_to_set(org, syncer, remote_set) -> dict:
     delete_locals = active_locals.exclude(**{syncer.local_id_attr + "__in": remote_identities})
 
     for local in delete_locals:
-        with syncer.lock(org, syncer.identify_local(local)):
-            syncer.delete_local(local)
-            outcome_counts[SyncOutcome.deleted] += 1
+        identity = syncer.identify_local(local)
+
+        with syncer.lock(org, identity):
+            # re-fetch inside the lock and re-check that this object still qualifies for deletion, as a concurrent
+            # sync may have changed it since the queryset was evaluated
+            local = syncer.fetch_local(org, identity)
+
+            if local and local.is_active and identity not in remote_identities:
+                syncer.delete_local(local)
+                outcome_counts[SyncOutcome.deleted] += 1
 
     return outcome_counts
 

--- a/test_runner/testapp/tests.py
+++ b/test_runner/testapp/tests.py
@@ -1,4 +1,5 @@
 import time
+from contextlib import contextmanager
 
 from temba_client.v2.types import Contact as TembaContact
 
@@ -149,6 +150,43 @@ class SyncTest(DashTest):
         Contact.objects.get(org=self.unicef, uuid="CF-002", name="Bob", backend=self.floip_backend, is_active=True)
         Contact.objects.get(org=self.unicef, uuid="CF-003", name="Colm", backend=self.floip_backend, is_active=True)
         Contact.objects.get(org=self.unicef, uuid="CF-005", name="Edward", backend=self.floip_backend, is_active=True)
+
+    def test_sync_local_to_set_recheck_under_lock(self):
+        Contact.objects.all().delete()  # start with no contacts...
+
+        Contact.objects.create(org=self.unicef, uuid="C-001", name="Anne", backend=self.rapidpro_backend)
+        Contact.objects.create(org=self.unicef, uuid="C-002", name="Bob", backend=self.rapidpro_backend)
+        Contact.objects.create(org=self.unicef, uuid="C-003", name="Colin", backend=self.rapidpro_backend)
+
+        remote_set = [TembaContact.create(uuid="C-001", name="Anne", status="active")]
+
+        real_lock = self.syncer.lock
+
+        @contextmanager
+        def racing_lock(org, identity):
+            with real_lock(org, identity):
+                # simulate concurrent syncs changing objects after the deletion queryset was evaluated but
+                # before this sync got the lock on them
+                if identity == "C-002":
+                    Contact.objects.filter(uuid="C-002").update(is_active=False)  # deactivated concurrently
+                elif identity == "C-003":
+                    Contact.objects.filter(uuid="C-003").delete()  # deleted concurrently
+                yield
+
+        self.syncer.lock = racing_lock
+        try:
+            outcome_counts = sync_local_to_set(self.unicef, self.syncer, remote_set)
+        finally:
+            self.syncer.lock = real_lock
+
+        # neither C-002 nor C-003 should have been deleted by this sync as they were re-checked under the lock
+        self.assertEqual(
+            {SyncOutcome.created: 0, SyncOutcome.updated: 0, SyncOutcome.deleted: 0, SyncOutcome.ignored: 1},
+            outcome_counts,
+        )
+        Contact.objects.get(org=self.unicef, uuid="C-001", is_active=True)
+        Contact.objects.get(org=self.unicef, uuid="C-002", is_active=False)
+        self.assertFalse(Contact.objects.filter(uuid="C-003").exists())
 
     def test_sync_local_to_changes(self):
         Contact.objects.all().delete()  # start with no contacts...

--- a/test_runner/testapp/tests.py
+++ b/test_runner/testapp/tests.py
@@ -177,11 +177,12 @@ class SyncTest(DashTest):
         try:
             outcome_counts = sync_local_to_set(self.unicef, self.syncer, remote_set)
         finally:
-            self.syncer.lock = real_lock
+            del self.syncer.lock
 
-        # neither C-002 nor C-003 should have been deleted by this sync as they were re-checked under the lock
+        # neither C-002 nor C-003 should have been deleted by this sync as they were re-checked under the lock, and
+        # both count as ignored so the outcome buckets still sum to the number of candidates
         self.assertEqual(
-            {SyncOutcome.created: 0, SyncOutcome.updated: 0, SyncOutcome.deleted: 0, SyncOutcome.ignored: 1},
+            {SyncOutcome.created: 0, SyncOutcome.updated: 0, SyncOutcome.deleted: 0, SyncOutcome.ignored: 3},
             outcome_counts,
         )
         Contact.objects.get(org=self.unicef, uuid="C-001", is_active=True)


### PR DESCRIPTION
In `sync_local_to_set`, the set of local objects to deactivate is computed before any per-object locks are taken, so a concurrent sync can change an object before the deletion loop reaches it. This caused two problems:

- if a candidate was concurrently hard-deleted, `delete_local`'s `save(update_fields=...)` affected 0 rows and raised a `DatabaseError`, crashing the sync
- if a candidate was concurrently deactivated, it was redundantly deactivated again and double-counted as deleted

The deletion loop now re-checks each candidate under its lock with a cheap `exists()` probe: candidates that no longer exist or are already inactive are skipped and counted as `ignored`, so outcome counts still sum to the number of objects considered.

Known limitation: an object re-affirmed by a concurrent sync after the deletion set is computed can still be deactivated, since the remote identity set is frozen before the loop. Closing that fully would require tracking a last-confirmed timestamp on synced objects. The re-check also assumes it sees committed state (READ COMMITTED/autocommit), so callers must not wrap syncs in an outer transaction that outlives the lock.