### PR TITLE
Fix Org.build_host_link null subdomain, https for custom domains, hostname typo

### DIFF
--- a/dash/orgs/models.py
+++ b/dash/orgs/models.py
@@ -11,7 +11,6 @@ from django.conf import settings
 from django.contrib.auth.models import Group, User
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 from dash.utils import generate_file_path
@@ -184,17 +183,15 @@ class Org(SmartModel):
         return TembaClient(host, api_token, user_agent=agent, transformer=transformer)
 
     def build_host_link(self, user_authenticated=False):
-        host_tld = getattr(settings, "HOSTNAME", "localhost")
+        host_tld = getattr(settings, "HOSTNAME", "") or "localhost"
         is_secure = getattr(settings, "SESSION_COOKIE_SECURE", False)
 
         prefix = "https://" if is_secure else "http://"
 
         if self.domain and is_secure and not user_authenticated:
-            return prefix + str(self.domain)
+            return prefix + self.domain
 
-        if not self.subdomain:
-            return prefix + host_tld
-        return prefix + force_str(self.subdomain) + "." + host_tld
+        return prefix + (f"{self.subdomain}.{host_tld}" if self.subdomain else host_tld)
 
     def get_task_state(self, task_key):
         return TaskState.get_or_create(self, task_key)

--- a/dash/orgs/models.py
+++ b/dash/orgs/models.py
@@ -184,18 +184,15 @@ class Org(SmartModel):
         return TembaClient(host, api_token, user_agent=agent, transformer=transformer)
 
     def build_host_link(self, user_authenticated=False):
-        host_tld = getattr(settings, "HOSTNAME", "locahost")
+        host_tld = getattr(settings, "HOSTNAME", "localhost")
         is_secure = getattr(settings, "SESSION_COOKIE_SECURE", False)
 
-        prefix = "http://"
+        prefix = "https://" if is_secure else "http://"
 
         if self.domain and is_secure and not user_authenticated:
             return prefix + str(self.domain)
 
-        if is_secure:
-            prefix = "https://"
-
-        if self.subdomain == "":
+        if not self.subdomain:
             return prefix + host_tld
         return prefix + force_str(self.subdomain) + "." + host_tld
 

--- a/test_runner/tests.py
+++ b/test_runner/tests.py
@@ -523,7 +523,6 @@ class OrgTest(DashTest):
                 self.assertEqual(self.org.build_host_link(True), "https://uganda.localhost:8000")
 
             self.org.subdomain = ""
-            self.org.save()
 
             self.assertEqual(self.org.build_host_link(), "http://localhost:8000")
             self.assertEqual(self.org.build_host_link(True), "http://localhost:8000")
@@ -533,7 +532,6 @@ class OrgTest(DashTest):
                 self.assertEqual(self.org.build_host_link(True), "https://localhost:8000")
 
             self.org.subdomain = None
-            self.org.save()
 
             self.assertEqual(self.org.build_host_link(), "http://localhost:8000")
             self.assertEqual(self.org.build_host_link(True), "http://localhost:8000")
@@ -543,8 +541,15 @@ class OrgTest(DashTest):
                 self.assertEqual(self.org.build_host_link(True), "https://localhost:8000")
 
             self.org.domain = "ureport.ug"
+
+            self.assertEqual(self.org.build_host_link(), "http://localhost:8000")
+            self.assertEqual(self.org.build_host_link(True), "http://localhost:8000")
+
+            with self.settings(SESSION_COOKIE_SECURE=True):
+                self.assertEqual(self.org.build_host_link(), "https://ureport.ug")
+                self.assertEqual(self.org.build_host_link(True), "https://localhost:8000")
+
             self.org.subdomain = "uganda"
-            self.org.save()
 
             self.assertEqual(self.org.build_host_link(), "http://uganda.localhost:8000")
             self.assertEqual(self.org.build_host_link(True), "http://uganda.localhost:8000")
@@ -552,6 +557,17 @@ class OrgTest(DashTest):
             with self.settings(SESSION_COOKIE_SECURE=True):
                 self.assertEqual(self.org.build_host_link(), "https://ureport.ug")
                 self.assertEqual(self.org.build_host_link(True), "https://uganda.localhost:8000")
+
+        # HOSTNAME empty falls back to localhost
+        self.org.domain = None
+        self.org.subdomain = "uganda"
+
+        with self.settings(HOSTNAME=""):
+            self.assertEqual(self.org.build_host_link(), "http://uganda.localhost")
+            self.assertEqual(self.org.build_host_link(True), "http://uganda.localhost")
+
+            self.org.subdomain = ""
+            self.assertEqual(self.org.build_host_link(), "http://localhost")
 
     def test_org_create(self):
         create_url = reverse("orgs.org_create")

--- a/test_runner/tests.py
+++ b/test_runner/tests.py
@@ -1,6 +1,5 @@
 import zoneinfo
-from dash.tags.models import Tag
-from unittest.mock import Mock, patch, call
+from unittest.mock import Mock, call, patch
 
 import valkey
 from smartmin.tests import SmartminTest
@@ -25,8 +24,9 @@ from dash.orgs.models import Invitation, Org, OrgBackend, OrgBackground, TaskSta
 from dash.orgs.tasks import org_task
 from dash.orgs.templatetags.dashorgs import display_time, national_phone
 from dash.stories.models import Story, StoryImage
-from dash.utils import random_string
+from dash.tags.models import Tag
 from dash.test import MockResponse
+from dash.utils import random_string
 
 
 class UserTest(SmartminTest):
@@ -532,6 +532,16 @@ class OrgTest(DashTest):
                 self.assertEqual(self.org.build_host_link(), "https://localhost:8000")
                 self.assertEqual(self.org.build_host_link(True), "https://localhost:8000")
 
+            self.org.subdomain = None
+            self.org.save()
+
+            self.assertEqual(self.org.build_host_link(), "http://localhost:8000")
+            self.assertEqual(self.org.build_host_link(True), "http://localhost:8000")
+
+            with self.settings(SESSION_COOKIE_SECURE=True):
+                self.assertEqual(self.org.build_host_link(), "https://localhost:8000")
+                self.assertEqual(self.org.build_host_link(True), "https://localhost:8000")
+
             self.org.domain = "ureport.ug"
             self.org.subdomain = "uganda"
             self.org.save()
@@ -540,7 +550,7 @@ class OrgTest(DashTest):
             self.assertEqual(self.org.build_host_link(True), "http://uganda.localhost:8000")
 
             with self.settings(SESSION_COOKIE_SECURE=True):
-                self.assertEqual(self.org.build_host_link(), "http://ureport.ug")
+                self.assertEqual(self.org.build_host_link(), "https://ureport.ug")
                 self.assertEqual(self.org.build_host_link(True), "https://uganda.localhost:8000")
 
     def test_org_create(self):


### PR DESCRIPTION
`Org.build_host_link()` only handled a blank subdomain, so an org with a NULL subdomain produced links like `http://None.example.com` — which flow into invitation emails. The custom-domain branch also always returned `http://` even on secure deployments (the subdomain branch already switched on `SESSION_COOKIE_SECURE`), and the hostname fallback had a typo ("locahost").

A None subdomain is now treated like blank, the scheme is computed once and applied to both branches, and the typo is fixed. Tests cover the None-subdomain and secure/insecure custom-domain cases.

Note that the custom-domain scheme change is an intentional reversal of earlier behavior that deliberately served custom-domain links over `http` (since custom domains might not have TLS configured). Custom-domain links now use `https` whenever the deployment signals secure cookies via `SESSION_COOKIE_SECURE`. Operators running a custom domain without TLS termination should not enable `SESSION_COOKIE_SECURE`, or should set up TLS for their custom domains before upgrading.