### PR TITLE
Fix deprecated datetime.utcfromtimestamp usage and stop union() mutating its arguments

### DIFF
--- a/dash/utils/__init__.py
+++ b/dash/utils/__init__.py
@@ -32,7 +32,8 @@ def intersection(*args):
 
 def union(*args):
     """
-    Return the union of lists, ordering by first seen in any list
+    Return the union of the given iterables as a new list, ordering items by first seen and leaving the arguments
+    unmodified
     """
     if not args:
         return []

--- a/dash/utils/__init__.py
+++ b/dash/utils/__init__.py
@@ -37,11 +37,11 @@ def union(*args):
     if not args:
         return []
 
-    base = args[0]
-    for other in args[1:]:
-        base.extend(other)
+    combined = []
+    for arg in args:
+        combined.extend(arg)
 
-    return list(OrderedDict.fromkeys(base))  # remove duplicates whilst preserving order
+    return list(OrderedDict.fromkeys(combined))  # remove duplicates whilst preserving order
 
 
 def random_string(length):
@@ -101,8 +101,8 @@ def ms_to_datetime(ms):
     """
     Converts a millisecond accuracy timestamp to a datetime
     """
-    dt = datetime.utcfromtimestamp(ms / 1000)
-    return dt.replace(microsecond=(ms % 1000) * 1000).replace(tzinfo=tzone.utc)
+    dt = datetime.fromtimestamp(ms / 1000, tz=tzone.utc)
+    return dt.replace(microsecond=(ms % 1000) * 1000)
 
 
 def get_month_range(d=None):

--- a/dash/utils/tests.py
+++ b/dash/utils/tests.py
@@ -98,6 +98,10 @@ class InitTest(DashTest):
         self.assertEqual(ms_to_datetime(datetime_to_ms(d3)), d3)
         self.assertEqual(ms_to_datetime(datetime_to_ms(d3)).tzinfo, tzone.utc)
 
+        # epoch and pre-epoch values
+        self.assertEqual(ms_to_datetime(0), datetime(1970, 1, 1, tzinfo=tzone.utc))
+        self.assertEqual(ms_to_datetime(-1500), datetime(1969, 12, 31, 23, 59, 58, 500000, tzinfo=tzone.utc))
+
     def test_get_month_range(self):
         self.assertEqual(
             get_month_range(datetime(2014, 2, 10, 12, 30, 0, 0, zoneinfo.ZoneInfo("Africa/Kigali"))),

--- a/dash/utils/tests.py
+++ b/dash/utils/tests.py
@@ -36,6 +36,12 @@ class InitTest(DashTest):
         self.assertEqual(union([2, 1, 1], [1, 2, 3]), [2, 1, 3])  # order is first seen
         self.assertEqual(union([2, 1], [2, 3, 3], [4, 5]), [2, 1, 3, 4, 5])
 
+        # arguments should be left unmodified
+        arg1, arg2 = [2, 1, 1], [1, 2, 3]
+        union(arg1, arg2)
+        self.assertEqual(arg1, [2, 1, 1])
+        self.assertEqual(arg2, [1, 2, 3])
+
     def test_random_string(self):
         rs = random_string(1000)
         self.assertEqual(1000, len(rs))
@@ -86,6 +92,11 @@ class InitTest(DashTest):
         d2 = datetime(2014, 1, 2, 3, 4, 5, 600000, tz)
         self.assertEqual(datetime_to_ms(d2), 1388624645600)
         self.assertEqual(ms_to_datetime(1388624645600), d2.astimezone(tzone.utc))
+
+        # round-trip: datetime -> ms -> datetime returns an aware UTC datetime
+        d3 = datetime(2021, 6, 7, 8, 9, 10, 111000, tzinfo=tzone.utc)
+        self.assertEqual(ms_to_datetime(datetime_to_ms(d3)), d3)
+        self.assertEqual(ms_to_datetime(datetime_to_ms(d3)).tzinfo, tzone.utc)
 
     def test_get_month_range(self):
         self.assertEqual(


### PR DESCRIPTION
`ms_to_datetime` used `datetime.utcfromtimestamp()`, deprecated since Python 3.12 — replaced with `datetime.fromtimestamp(..., tz=timezone.utc)` with an identical aware-UTC return value. `union()` also extended its first argument in place, silently growing a caller's (possibly shared) list — it now builds a new list with the same dedup/ordering semantics. Tests cover the round-trip and non-mutation.