### PR TITLE
Remove unused gettext install from CI, use SPDX license expression, clean up stale test settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
 
       - name: Run pre-test checks
         run: |
-          sudo apt-get install gettext
           uv run python ./code_check.py --debug
 
       - name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ source = ["dash"]
 omit = ["*/migrations/*", "*/tests*", "*__init__*", "*settings*", "*management/commands*", "dash/test.py"]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,11 @@ description = "Support library for RapidPro dashboards"
 authors = [
     {"name" = "Nyaruka", "email" = "code@nyaruka.com"}
 ]
-license = { text = "BSD" }
+license = "BSD-3-Clause"
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Framework :: Django",

--- a/test_runner/settings.py
+++ b/test_runner/settings.py
@@ -102,11 +102,6 @@ STATIC_ROOT = ""
 # Example: "http://media.lawrence.com/static/"
 STATIC_URL = "/static/"
 
-# URL prefix for admin static files -- CSS, JavaScript and images.
-# Make sure to use a trailing slash.
-# Examples: "http://foo.com/static/admin/", "/static/admin/".
-ADMIN_MEDIA_PREFIX = "/static/admin/"
-
 # Additional locations of static files
 STATICFILES_DIRS = (
     # Put strings here, like "/home/html/static" or "C:/www/django/static".
@@ -157,13 +152,7 @@ GROUP_PERMISSIONS = {
         "categories.categoryimage.*",
         "dashblocks.dashblock.*",
         "dashblocks.dashblocktype.*",
-        "news.newsitem.*",
-        "news.video.*",
         "orgs.org_home",
-        "polls.poll.*",
-        "polls.pollcategory.*",
-        "polls.pollimage.*",
-        "polls.featuredresponse.*",
         "stories.story.*",
         "stories.storyimage.*",
         "tags.tag.*",


### PR DESCRIPTION
Small chores: the CI workflow installed gettext but nothing uses it (no locale files, and the code checks no longer run makemessages); the license metadata used the deprecated table form, now a PEP 639 SPDX expression (`BSD-3-Clause`, matching the LICENSE file, with the redundant trove classifier dropped — build verified); and the test settings carried `ADMIN_MEDIA_PREFIX` (removed in Django 1.4) plus group permissions referencing apps that don't exist in this project.